### PR TITLE
Redirect install log standard out to /tmp

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -5,10 +5,10 @@ set -e
 # Install tmate on macOS or Ubuntu
 echo Setting up tmate...
 if [ -x "$(command -v brew)" ]; then
-  brew install tmate
+  brew install tmate > /tmp/brew.log
 fi
 if [ -x "$(command -v apt-get)" ]; then
-  sudo apt-get install -y tmate openssh-client
+  sudo apt-get install -y tmate openssh-client > /tmp/apt-get.log
 fi
 
 # Generate ssh key if needed


### PR DESCRIPTION
This is to reduce noise in the build log. Don't redirect standard error in case there is a problem with the script.